### PR TITLE
Use tabs instead of spaces in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,21 +6,21 @@ const tsProject = typescript.createProject('tsconfig.json');
 
 // Compile the TS sources
 gulp.task('typescript', () => {
-    tsProject.src()
-        .pipe(sourcemaps.init())
-        .pipe(tsProject()).on('error', gutil.log)
-        .pipe(sourcemaps.write())
-        .pipe(gulp.dest(tsProject.options.outDir));
+	tsProject.src()
+	.pipe(sourcemaps.init())
+	.pipe(tsProject()).on('error', gutil.log)
+	.pipe(sourcemaps.write())
+	.pipe(gulp.dest(tsProject.options.outDir));
 });
 
 // Copy any pre-defined declarations
 gulp.task('copydecs', () => {
-    const decDirs = [];
-    tsProject.config.include.forEach((dir) => {
-        decDirs.push(`${dir.split('/')[0]}/**/*.d.ts`);
-    });
-    gulp.src(decDirs)
-        .pipe(gulp.dest(tsProject.options.declarationDir));
+	const decDirs = [];
+	tsProject.config.include.forEach((dir) => {
+		decDirs.push(`${dir.split('/')[0]}/**/*.d.ts`);
+	});
+	gulp.src(decDirs)
+	.pipe(gulp.dest(tsProject.options.declarationDir));
 });
 
 gulp.task('build', [ 'typescript', 'copydecs' ]);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>